### PR TITLE
Update metrics definition and implementation to be in line with go-grpc-prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,32 @@ variable `grpc_server_handling_seconds`. The histogram variable contains three s
 - enable_client_stream_receive_time_histogram: Enables 'grpc_client_msg_recv_handling_seconds'
 - enable_client_stream_send_time_histogram: Enables 'grpc_client_msg_send_handling_seconds'
 
+## Legacy metrics:
+
+Metric names have been updated to be in line with those from https://github.com/grpc-ecosystem/go-grpc-prometheus.
+The legacy metrics are:
+
+### server side:
+- grpc_server_started_total
+- grpc_server_handled_total
+- grpc_server_handled_latency_seconds
+- grpc_server_msg_received_total
+- grpc_server_msg_sent_total
+
+### client side:
+- grpc_client_started_total
+- grpc_client_completed
+- grpc_client_completed_latency_seconds
+- grpc_client_msg_sent_total
+- grpc_client_msg_received_total
+
+In order to be able to use these legacy metrics for backwards compatibility, the `legacy` flag can be set to `True` when initialising the server/client interceptors
+
+For example, to enable the server side legacy metrics:
+```jsoniq
+server = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
+                     interceptors=(PromServerInterceptor(legacy=True),))
+```
 
 ## How to run and test
 1. Run the testing server

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ variable `grpc_server_handling_seconds`. The histogram variable contains three s
 ## Legacy metrics:
 
 Metric names have been updated to be in line with those from https://github.com/grpc-ecosystem/go-grpc-prometheus.
+
 The legacy metrics are:
 
 ### server side:

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ Currently, the library has the parity metrics with the Java and Go library.
 ### Server side:
 - grpc_server_started_total
 - grpc_server_handled_total
-- grpc_server_handled_latency_seconds
 - grpc_server_msg_received_total
 - grpc_server_msg_sent_total
+- grpc_server_handling_seconds
 
 ### Client side:
 - grpc_client_started_total
-- grpc_client_completed
-- grpc_client_completed_latency_seconds
-- grpc_client_msg_sent_total
+- grpc_client_handled_total
 - grpc_client_msg_received_total
+- grpc_client_msg_sent_total
+- grpc_client_handling_seconds
+- grpc_client_msg_recv_handling_seconds
+- grpc_client_msg_send_handling_seconds
 
 ## How to use
 
@@ -62,6 +64,37 @@ server = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
 # Start an end point to expose metrics.
 start_http_server(metrics_port)
 ```
+
+## Histograms
+
+[Prometheus histograms](https://prometheus.io/docs/concepts/metric_types/#histogram) are a great way
+to measure latency distributions of your RPCs. However, since it is bad practice to have metrics
+of [high cardinality](https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels)
+the latency monitoring metrics are disabled by default. To enable them please call the following
+in your interceptor initialization code:
+
+```jsoniq
+server = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
+                     interceptors=(PromServerInterceptor(enable_handling_time_histogram=True),))
+```
+
+After the call completes, its handling time will be recorded in a [Prometheus histogram](https://prometheus.io/docs/concepts/metric_types/#histogram)
+variable `grpc_server_handling_seconds`. The histogram variable contains three sub-metrics:
+
+ * `grpc_server_handling_seconds_count` - the count of all completed RPCs by status and method 
+ * `grpc_server_handling_seconds_sum` - cumulative time of RPCs by status and method, useful for 
+   calculating average handling times
+ * `grpc_server_handling_seconds_bucket` - contains the counts of RPCs by status and method in respective
+   handling-time buckets. These buckets can be used by Prometheus to estimate SLAs (see [here](https://prometheus.io/docs/practices/histograms/))
+
+## Server Side:
+- enable_handling_time_histogram: Enables 'grpc_server_handling_seconds'
+
+## Client Side:
+- enable_client_handling_time_histogram: Enables 'grpc_client_handling_seconds'
+- enable_client_stream_receive_time_histogram: Enables 'grpc_client_msg_recv_handling_seconds'
+- enable_client_stream_send_time_histogram: Enables 'grpc_client_msg_send_handling_seconds'
+
 
 ## How to run and test
 1. Run the testing server

--- a/py_grpc_prometheus/client_metrics.py
+++ b/py_grpc_prometheus/client_metrics.py
@@ -37,3 +37,31 @@ GRPC_CLIENT_STREAM_SEND_HISTOGRAM = Histogram(
   "grpc_client_msg_send_handling_seconds",
   "Histogram of response latency (seconds) of the gRPC single message send.",
   ["grpc_type", "grpc_service", "grpc_method"])
+
+# Legacy metrics for backwards compatibility
+LEGACY_GRPC_CLIENT_STARTED_TOTAL_COUNTER = Counter(
+  "grpc_client_started_total",
+  "Total number of RPCs started on the client",
+  ["grpc_type", "grpc_service", "grpc_method"])
+
+LEGACY_GRPC_CLIENT_COMPLETED_COUNTER = Counter(
+  "grpc_client_completed",
+  "Total number of RPCs completed on the client, "
+  "regardless of success or failure.",
+  ["grpc_type", "grpc_service", "grpc_method", "code"])
+
+LEGACY_GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM = Histogram(
+  "grpc_client_completed_latency_seconds",
+  "Histogram of rpc response latency (in seconds) for completed rpcs.",
+  ["grpc_type", "grpc_service", "grpc_method"])
+
+LEGACY_GRPC_CLIENT_MSG_RECEIVED_TOTAL_COUNTER = Counter(
+  "grpc_client_msg_received_total",
+  "Total number of stream messages received from the server.",
+  ["grpc_type", "grpc_service", "grpc_method"]
+)
+
+LEGACY_GRPC_CLIENT_MSG_SENT_TOTAL_COUNTER = Counter(
+  "grpc_client_msg_sent_total",
+  "Total number of stream messages sent by the client.",
+  ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/client_metrics.py
+++ b/py_grpc_prometheus/client_metrics.py
@@ -2,38 +2,38 @@ from prometheus_client import Counter
 from prometheus_client import Histogram
 
 GRPC_CLIENT_STARTED_COUNTER = Counter(
-    "grpc_client_started_total",
-    "Total number of RPCs started on the client",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_client_started_total",
+  "Total number of RPCs started on the client",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_CLIENT_HANDLED_COUNTER = Counter(
-    "grpc_client_handled_total",
-    "Total number of RPCs completed on the client, "
-    "regardless of success or failure.",
-    ["grpc_type", "grpc_service", "grpc_method", "grpc_code"])
+  "grpc_client_handled_total",
+  "Total number of RPCs completed on the client, "
+  "regardless of success or failure.",
+  ["grpc_type", "grpc_service", "grpc_method", "grpc_code"])
 
 GRPC_CLIENT_STREAM_MSG_RECEIVED = Counter(
-    "grpc_client_msg_received_total",
-    "Total number of RPC stream messages received by the client.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_client_msg_received_total",
+  "Total number of RPC stream messages received by the client.",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_CLIENT_STREAM_MSG_SENT = Counter(
-    "grpc_client_msg_sent_total",
-    "Total number of gRPC stream messages sent by the client.",
-    ["grpc_type", "grpc_service", "grpc_method"]
+  "grpc_client_msg_sent_total",
+  "Total number of gRPC stream messages sent by the client.",
+  ["grpc_type", "grpc_service", "grpc_method"]
 )
 
 GRPC_CLIENT_HANDLED_HISTOGRAM = Histogram(
-    "grpc_client_handling_seconds",
-    "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_client_handling_seconds",
+  "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_CLIENT_STREAM_RECV_HISTOGRAM = Histogram(
-    "grpc_client_msg_recv_handling_seconds",
-    "Histogram of response latency (seconds) of the gRPC single message receive.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_client_msg_recv_handling_seconds",
+  "Histogram of response latency (seconds) of the gRPC single message receive.",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_CLIENT_STREAM_SEND_HISTOGRAM = Histogram(
-    "grpc_client_msg_send_handling_seconds",
-    "Histogram of response latency (seconds) of the gRPC single message send.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_client_msg_send_handling_seconds",
+  "Histogram of response latency (seconds) of the gRPC single message send.",
+  ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/client_metrics.py
+++ b/py_grpc_prometheus/client_metrics.py
@@ -1,31 +1,39 @@
 from prometheus_client import Counter
 from prometheus_client import Histogram
 
-GRPC_CLIENT_STARTED_TOTAL_COUNTER = Counter(
+GRPC_CLIENT_STARTED_COUNTER = Counter(
     "grpc_client_started_total",
     "Total number of RPCs started on the client",
     ["grpc_type", "grpc_service", "grpc_method"])
 
-GRPC_CLIENT_COMPLETED_COUNTER = Counter(
-    "grpc_client_completed",
+GRPC_CLIENT_HANDLED_COUNTER = Counter(
+    "grpc_client_handled_total",
     "Total number of RPCs completed on the client, "
     "regardless of success or failure.",
-    ["grpc_type", "grpc_service", "grpc_method", "code"])
+    ["grpc_type", "grpc_service", "grpc_method", "grpc_code"])
 
-GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM = Histogram(
-    "grpc_client_completed_latency_seconds",
-    "Histogram of rpc response latency (in seconds) for completed rpcs.",
-    ["grpc_type", "grpc_service", "grpc_method"])
-
-
-GRPC_CLIENT_MSG_RECEIVED_TOTAL_COUNTER = Counter(
+GRPC_CLIENT_STREAM_MSG_RECEIVED = Counter(
     "grpc_client_msg_received_total",
-    "Total number of stream messages received from the server.",
+    "Total number of RPC stream messages received by the client.",
     ["grpc_type", "grpc_service", "grpc_method"])
 
-
-GRPC_CLIENT_MSG_SENT_TOTAL_COUNTER = Counter(
+GRPC_CLIENT_STREAM_MSG_SENT = Counter(
     "grpc_client_msg_sent_total",
-    "Total number of stream messages sent by the client.",
+    "Total number of gRPC stream messages sent by the client.",
     ["grpc_type", "grpc_service", "grpc_method"]
 )
+
+GRPC_CLIENT_HANDLED_HISTOGRAM = Histogram(
+    "grpc_client_handling_seconds",
+    "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
+    ["grpc_type", "grpc_service", "grpc_method"])
+
+GRPC_CLIENT_STREAM_RECV_HISTOGRAM = Histogram(
+    "grpc_client_msg_recv_handling_seconds",
+    "Histogram of response latency (seconds) of the gRPC single message receive.",
+    ["grpc_type", "grpc_service", "grpc_method"])
+
+GRPC_CLIENT_STREAM_SEND_HISTOGRAM = Histogram(
+    "grpc_client_msg_send_handling_seconds",
+    "Histogram of response latency (seconds) of the gRPC single message send.",
+    ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/grpc_utils.py
+++ b/py_grpc_prometheus/grpc_utils.py
@@ -10,9 +10,9 @@ def wrap_iterator_inc_counter(iterator, counter, grpc_type, grpc_service_name, g
 
   for item in iterator:
     counter.labels(
-        grpc_type=grpc_type,
-        grpc_service=grpc_service_name,
-        grpc_method=grpc_method_name).inc()
+      grpc_type=grpc_type,
+      grpc_service=grpc_service_name,
+      grpc_method=grpc_method_name).inc()
     yield item
 
 

--- a/py_grpc_prometheus/prometheus_client_interceptor.py
+++ b/py_grpc_prometheus/prometheus_client_interceptor.py
@@ -5,11 +5,13 @@ from timeit import default_timer
 import grpc
 
 import py_grpc_prometheus.grpc_utils as grpc_utils
+from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STARTED_COUNTER
 from py_grpc_prometheus.client_metrics import GRPC_CLIENT_HANDLED_COUNTER
-from py_grpc_prometheus.client_metrics import GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM
 from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_MSG_RECEIVED
 from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_MSG_SENT
-from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STARTED_COUNTER
+from py_grpc_prometheus.client_metrics import GRPC_CLIENT_HANDLED_HISTOGRAM
+from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_RECV_HISTOGRAM
+from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_SEND_HISTOGRAM
 
 
 class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
@@ -19,6 +21,12 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
   """
   Intercept gRPC client requests.
   """
+
+  def __init__(self, enable_client_handling_time_histogram=False, enable_client_stream_receive_time_histogram=False, enable_client_stream_send_time_histogram=False):
+    self._enable_client_handling_time_histogram = enable_client_handling_time_histogram
+    self._enable_client_stream_receive_time_histogram = enable_client_stream_receive_time_histogram
+    self._enable_client_stream_send_time_histogram = enable_client_stream_send_time_histogram
+    super().__init__()
 
   def intercept_unary_unary(self, continuation, client_call_details, request):
     grpc_service_name, grpc_method_name, _ = grpc_utils.split_method_call(client_call_details)
@@ -32,10 +40,11 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
     start = default_timer()
     handler = continuation(client_call_details, request)
 
-    GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM.labels(
-        grpc_type=grpc_type,
-        grpc_service=grpc_service_name,
-        grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+    if self._enable_client_handling_time_histogram:
+      GRPC_CLIENT_HANDLED_HISTOGRAM.labels(
+          grpc_type=grpc_type,
+          grpc_service=grpc_service_name,
+          grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
     GRPC_CLIENT_HANDLED_COUNTER.labels(
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,
@@ -54,10 +63,11 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
 
     start = default_timer()
     handler = continuation(client_call_details, request)
-    GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM.labels(
-        grpc_type=grpc_type,
-        grpc_service=grpc_service_name,
-        grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+    if self._enable_client_handling_time_histogram:
+      GRPC_CLIENT_HANDLED_HISTOGRAM.labels(
+          grpc_type=grpc_type,
+          grpc_service=grpc_service_name,
+          grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
 
     return grpc_utils.wrap_iterator_inc_counter(
         handler,
@@ -83,10 +93,11 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,
         grpc_method=grpc_method_name).inc()
-    GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM.labels(
-        grpc_type=grpc_type,
-        grpc_service=grpc_service_name,
-        grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+    if self._enable_client_handling_time_histogram:
+      GRPC_CLIENT_HANDLED_HISTOGRAM.labels(
+          grpc_type=grpc_type,
+          grpc_service=grpc_service_name,
+          grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
     return handler
 
   def intercept_stream_stream(self, continuation, client_call_details, request_iterator):

--- a/py_grpc_prometheus/prometheus_client_interceptor.py
+++ b/py_grpc_prometheus/prometheus_client_interceptor.py
@@ -12,6 +12,12 @@ from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_MSG_RECEIVED
 from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_MSG_SENT
 from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_RECV_HISTOGRAM
 from py_grpc_prometheus.client_metrics import GRPC_CLIENT_STREAM_SEND_HISTOGRAM
+# Legacy metrics
+from py_grpc_prometheus.client_metrics import LEGACY_GRPC_CLIENT_COMPLETED_COUNTER
+from py_grpc_prometheus.client_metrics import LEGACY_GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM
+from py_grpc_prometheus.client_metrics import LEGACY_GRPC_CLIENT_MSG_RECEIVED_TOTAL_COUNTER
+from py_grpc_prometheus.client_metrics import LEGACY_GRPC_CLIENT_MSG_SENT_TOTAL_COUNTER
+from py_grpc_prometheus.client_metrics import LEGACY_GRPC_CLIENT_STARTED_TOTAL_COUNTER
 
 
 class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
@@ -22,59 +28,102 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
   Intercept gRPC client requests.
   """
 
-  def __init__(self, enable_client_handling_time_histogram=False, enable_client_stream_receive_time_histogram=False, enable_client_stream_send_time_histogram=False):
+  def __init__(
+          self,
+          enable_client_handling_time_histogram=False,
+          enable_client_stream_receive_time_histogram=False,
+          enable_client_stream_send_time_histogram=False,
+          legacy=False
+  ):
     self._enable_client_handling_time_histogram = enable_client_handling_time_histogram
     self._enable_client_stream_receive_time_histogram = enable_client_stream_receive_time_histogram
     self._enable_client_stream_send_time_histogram = enable_client_stream_send_time_histogram
+    self._legacy = legacy
 
   def intercept_unary_unary(self, continuation, client_call_details, request):
     grpc_service_name, grpc_method_name, _ = grpc_utils.split_method_call(client_call_details)
     grpc_type = grpc_utils.UNARY
 
-    GRPC_CLIENT_STARTED_COUNTER.labels(
-      grpc_type=grpc_type,
-      grpc_service=grpc_service_name,
-      grpc_method=grpc_method_name).inc()
+    if self._legacy:
+      LEGACY_GRPC_CLIENT_STARTED_TOTAL_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).inc()
+    else:
+      GRPC_CLIENT_STARTED_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).inc()
 
     start = default_timer()
     handler = continuation(client_call_details, request)
-
-    if self._enable_client_handling_time_histogram:
+    if self._legacy:
+      LEGACY_GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+    elif self._enable_client_handling_time_histogram:
       GRPC_CLIENT_HANDLED_HISTOGRAM.labels(
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,
         grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
-    GRPC_CLIENT_HANDLED_COUNTER.labels(
-      grpc_type=grpc_type,
-      grpc_service=grpc_service_name,
-      grpc_method=grpc_method_name,
-      code=handler.code().name).inc()
+
+    if self._legacy:
+      LEGACY_GRPC_CLIENT_COMPLETED_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name,
+        code=handler.code().name).inc()
+    else:
+      GRPC_CLIENT_HANDLED_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name,
+        code=handler.code().name).inc()
+
     return handler
 
   def intercept_unary_stream(self, continuation, client_call_details, request):
     grpc_service_name, grpc_method_name, _ = grpc_utils.split_method_call(client_call_details)
     grpc_type = grpc_utils.SERVER_STREAMING
 
-    GRPC_CLIENT_STARTED_COUNTER.labels(
-      grpc_type=grpc_type,
-      grpc_service=grpc_service_name,
-      grpc_method=grpc_method_name).inc()
+    if self._legacy:
+      LEGACY_GRPC_CLIENT_STARTED_TOTAL_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).inc()
+    else:
+      GRPC_CLIENT_STARTED_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).inc()
 
     start = default_timer()
     handler = continuation(client_call_details, request)
-    if self._enable_client_handling_time_histogram:
+    if self._legacy:
+      LEGACY_GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+
+    elif self._enable_client_handling_time_histogram:
       GRPC_CLIENT_HANDLED_HISTOGRAM.labels(
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,
         grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
 
+    handler_metric = GRPC_CLIENT_STREAM_MSG_RECEIVED
+    if self._legacy:
+      handler_metric = LEGACY_GRPC_CLIENT_MSG_RECEIVED_TOTAL_COUNTER
+
     handler = grpc_utils.wrap_iterator_inc_counter(
       handler,
-      GRPC_CLIENT_STREAM_MSG_RECEIVED,
+      handler_metric,
       grpc_type,
       grpc_service_name,
       grpc_method_name)
-    if self._enable_client_stream_receive_time_histogram:
+
+    if self._enable_client_stream_receive_time_histogram and not self._legacy:
       GRPC_CLIENT_STREAM_RECV_HISTOGRAM.labels(
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,
@@ -86,29 +135,47 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
     grpc_service_name, grpc_method_name, _ = grpc_utils.split_method_call(client_call_details)
     grpc_type = grpc_utils.CLIENT_STREAMING
 
+    iterator_metric = GRPC_CLIENT_STREAM_MSG_SENT
+    if self._legacy:
+      iterator_metric = LEGACY_GRPC_CLIENT_MSG_SENT_TOTAL_COUNTER
+
     request_iterator = grpc_utils.wrap_iterator_inc_counter(
       request_iterator,
-      GRPC_CLIENT_STREAM_MSG_SENT,
+      iterator_metric,
       grpc_type,
       grpc_service_name,
       grpc_method_name)
 
     start = default_timer()
     handler = continuation(client_call_details, request_iterator)
-    GRPC_CLIENT_STARTED_COUNTER.labels(
-      grpc_type=grpc_type,
-      grpc_service=grpc_service_name,
-      grpc_method=grpc_method_name).inc()
-    if self._enable_client_handling_time_histogram:
+
+    if self._legacy:
+      LEGACY_GRPC_CLIENT_STARTED_TOTAL_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).inc()
+      LEGACY_GRPC_CLIENT_COMPLETED_LATENCY_SECONDS_HISTOGRAM.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+    else:
+      GRPC_CLIENT_STARTED_COUNTER.labels(
+        grpc_type=grpc_type,
+        grpc_service=grpc_service_name,
+        grpc_method=grpc_method_name).inc()
+
+    if self._enable_client_handling_time_histogram and not self._legacy:
       GRPC_CLIENT_HANDLED_HISTOGRAM.labels(
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,
         grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
-    if self._enable_client_stream_send_time_histogram:
+
+    if self._enable_client_stream_send_time_histogram and not self._legacy:
       GRPC_CLIENT_STREAM_SEND_HISTOGRAM.labels(
         grpc_type=grpc_type,
-        grpc_Service=grpc_service_name,
+        grpc_service=grpc_service_name,
         grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
+
     return handler
 
   def intercept_stream_stream(self, continuation, client_call_details, request_iterator):
@@ -116,29 +183,38 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
       client_call_details)
     grpc_type = grpc_utils.BIDI_STREAMING
     start = default_timer()
+
+    iterator_sent_metric = GRPC_CLIENT_STREAM_MSG_SENT
+    if self._legacy:
+      iterator_sent_metric = LEGACY_GRPC_CLIENT_MSG_SENT_TOTAL_COUNTER
+
     response_iterator = continuation(
       client_call_details,
       grpc_utils.wrap_iterator_inc_counter(
         request_iterator,
-        GRPC_CLIENT_STREAM_MSG_SENT,
+        iterator_sent_metric,
         grpc_type,
         grpc_service_name,
         grpc_method_name))
 
-    if self._enable_client_stream_send_time_histogram:
+    if self._enable_client_stream_send_time_histogram and not self._legacy:
       GRPC_CLIENT_STREAM_SEND_HISTOGRAM.labels(
         grpc_type=grpc_type,
         grpc_Service=grpc_service_name,
         grpc_method=grpc_method_name).observe(max(default_timer() - start, 0))
 
+    iterator_received_metric = GRPC_CLIENT_STREAM_MSG_RECEIVED
+    if self._legacy:
+      iterator_received_metric = LEGACY_GRPC_CLIENT_MSG_RECEIVED_TOTAL_COUNTER
+
     response_iterator = grpc_utils.wrap_iterator_inc_counter(
       response_iterator,
-      GRPC_CLIENT_STREAM_MSG_RECEIVED,
+      iterator_received_metric,
       grpc_type,
       grpc_service_name,
       grpc_method_name)
 
-    if self._enable_client_stream_receive_time_histogram:
+    if self._enable_client_stream_receive_time_histogram and not self._legacy:
       GRPC_CLIENT_STREAM_RECV_HISTOGRAM.labels(
         grpc_type=grpc_type,
         grpc_service=grpc_service_name,

--- a/py_grpc_prometheus/prometheus_client_interceptor.py
+++ b/py_grpc_prometheus/prometheus_client_interceptor.py
@@ -26,7 +26,6 @@ class PromClientInterceptor(grpc.UnaryUnaryClientInterceptor,
     self._enable_client_handling_time_histogram = enable_client_handling_time_histogram
     self._enable_client_stream_receive_time_histogram = enable_client_stream_receive_time_histogram
     self._enable_client_stream_send_time_histogram = enable_client_stream_send_time_histogram
-    super().__init__()
 
   def intercept_unary_unary(self, continuation, client_call_details, request):
     grpc_service_name, grpc_method_name, _ = grpc_utils.split_method_call(client_call_details)

--- a/py_grpc_prometheus/prometheus_server_interceptor.py
+++ b/py_grpc_prometheus/prometheus_server_interceptor.py
@@ -16,7 +16,6 @@ class PromServerInterceptor(grpc.ServerInterceptor):
 
   def __init__(self, enable_handling_time_histogram=False):
     self._enable_handling_time_histogram = enable_handling_time_histogram
-    super().__init__()
 
   def intercept_service(self, continuation, handler_call_details):
     """

--- a/py_grpc_prometheus/prometheus_server_interceptor.py
+++ b/py_grpc_prometheus/prometheus_server_interceptor.py
@@ -6,10 +6,10 @@ import grpc
 
 import py_grpc_prometheus.grpc_utils as grpc_utils
 from py_grpc_prometheus.server_metrics import GRPC_SERVER_HANDLED_LATENCY_SECONDS
-from py_grpc_prometheus.server_metrics import GRPC_SERVER_HANDLED_TOTAL_COUNTER
+from py_grpc_prometheus.server_metrics import GRPC_SERVER_HANDLED_COUNTER
 from py_grpc_prometheus.server_metrics import GRPC_SERVER_MSG_RECEIVED_TOTAL_COUNTER
-from py_grpc_prometheus.server_metrics import GRPC_SERVER_MSG_SENT_TOTAL_COUNTER
-from py_grpc_prometheus.server_metrics import GRPC_SERVER_STARTED_TOTAL_COUNTER
+from py_grpc_prometheus.server_metrics import GRPC_SERVER_STREAM_MSG_RECEIVED
+from py_grpc_prometheus.server_metrics import GRPC_SERVER_STARTED_COUNTER
 
 
 class PromServerInterceptor(grpc.ServerInterceptor):
@@ -41,7 +41,7 @@ class PromServerInterceptor(grpc.ServerInterceptor):
                 grpc_service_name,
                 grpc_method_name)
           else:
-            GRPC_SERVER_STARTED_TOTAL_COUNTER.labels(
+            GRPC_SERVER_STARTED_COUNTER.labels(
                 grpc_type=grpc_type,
                 grpc_service=grpc_service_name,
                 grpc_method=grpc_method_name) \
@@ -53,19 +53,19 @@ class PromServerInterceptor(grpc.ServerInterceptor):
           if response_streaming:
             response_or_iterator = grpc_utils.wrap_iterator_inc_counter(
                 response_or_iterator,
-                GRPC_SERVER_MSG_SENT_TOTAL_COUNTER,
+                GRPC_SERVER_STREAM_MSG_RECEIVED,
                 grpc_type,
                 grpc_service_name,
                 grpc_method_name)
           else:
-            GRPC_SERVER_HANDLED_TOTAL_COUNTER.labels(
+            GRPC_SERVER_HANDLED_COUNTER.labels(
                 grpc_type=grpc_type,
                 grpc_service=grpc_service_name,
                 grpc_method=grpc_method_name,
                 code=self._compute_status_code(servicer_context).name).inc()
           return response_or_iterator
         except grpc.RpcError as e:
-          GRPC_SERVER_HANDLED_TOTAL_COUNTER.labels(
+          GRPC_SERVER_HANDLED_COUNTER.labels(
               grpc_type=grpc_type,
               grpc_service=grpc_service_name,
               grpc_method=grpc_method_name,

--- a/py_grpc_prometheus/prometheus_server_interceptor.py
+++ b/py_grpc_prometheus/prometheus_server_interceptor.py
@@ -10,12 +10,19 @@ from py_grpc_prometheus.server_metrics import GRPC_SERVER_HANDLED_HISTOGRAM
 from py_grpc_prometheus.server_metrics import GRPC_SERVER_STARTED_COUNTER
 from py_grpc_prometheus.server_metrics import GRPC_SERVER_STREAM_MSG_RECEIVED
 from py_grpc_prometheus.server_metrics import GRPC_SERVER_STREAM_MSG_SENT
+# Legacy metrics
+from py_grpc_prometheus.server_metrics import LEGACY_GRPC_SERVER_HANDLED_LATENCY_SECONDS
+from py_grpc_prometheus.server_metrics import LEGACY_GRPC_SERVER_HANDLED_TOTAL_COUNTER
+from py_grpc_prometheus.server_metrics import LEGACY_GRPC_SERVER_MSG_RECEIVED_TOTAL_COUNTER
+from py_grpc_prometheus.server_metrics import LEGACY_GRPC_SERVER_MSG_SENT_TOTAL_COUNTER
+from py_grpc_prometheus.server_metrics import LEGACY_GRPC_SERVER_STARTED_TOTAL_COUNTER
 
 
 class PromServerInterceptor(grpc.ServerInterceptor):
 
-  def __init__(self, enable_handling_time_histogram=False):
+  def __init__(self, enable_handling_time_histogram=False, legacy=False):
     self._enable_handling_time_histogram = enable_handling_time_histogram
+    self._legacy = legacy
 
   def intercept_service(self, continuation, handler_call_details):
     """
@@ -36,6 +43,11 @@ class PromServerInterceptor(grpc.ServerInterceptor):
         start = default_timer()
         grpc_type = grpc_utils.get_method_type(request_streaming, response_streaming)
         try:
+
+          received_metric = GRPC_SERVER_STREAM_MSG_RECEIVED
+          if self._legacy:
+            received_metric = LEGACY_GRPC_SERVER_MSG_RECEIVED_TOTAL_COUNTER
+
           if request_streaming:
             request_or_iterator = grpc_utils.wrap_iterator_inc_counter(
               request_or_iterator,
@@ -43,56 +55,99 @@ class PromServerInterceptor(grpc.ServerInterceptor):
               grpc_type,
               grpc_service_name,
               grpc_method_name)
-            request_or_iterator = grpc_utils.wrap_iterator_inc_counter(
-              request_or_iterator,
-              GRPC_SERVER_STREAM_MSG_SENT,
-              grpc_type,
-              grpc_service_name,
-              grpc_method_name)
+            if not self._legacy:
+              request_or_iterator = grpc_utils.wrap_iterator_inc_counter(
+                request_or_iterator,
+                GRPC_SERVER_STREAM_MSG_SENT,
+                grpc_type,
+                grpc_service_name,
+                grpc_method_name)
           else:
-            GRPC_SERVER_STARTED_COUNTER.labels(
-              grpc_type=grpc_type,
-              grpc_service=grpc_service_name,
-              grpc_method=grpc_method_name) \
-              .inc()
+            if self._legacy:
+              LEGACY_GRPC_SERVER_STARTED_TOTAL_COUNTER.labels(
+                grpc_type=grpc_type,
+                grpc_service=grpc_service_name,
+                grpc_method=grpc_method_name) \
+                .inc()
+            else:
+              GRPC_SERVER_STARTED_COUNTER.labels(
+                grpc_type=grpc_type,
+                grpc_service=grpc_service_name,
+                grpc_method=grpc_method_name) \
+                .inc()
 
           # Invoke the original rpc behavior.
           response_or_iterator = behavior(request_or_iterator, servicer_context)
 
           if response_streaming:
+
+            sent_metric = GRPC_SERVER_STREAM_MSG_SENT
+            if self._legacy:
+              sent_metric = LEGACY_GRPC_SERVER_MSG_SENT_TOTAL_COUNTER
+
+            if not self._legacy:
+              response_or_iterator = grpc_utils.wrap_iterator_inc_counter(
+                response_or_iterator,
+                GRPC_SERVER_STREAM_MSG_RECEIVED,
+                grpc_type,
+                grpc_service_name,
+                grpc_method_name)
+
             response_or_iterator = grpc_utils.wrap_iterator_inc_counter(
               response_or_iterator,
-              GRPC_SERVER_STREAM_MSG_RECEIVED,
+              sent_metric,
               grpc_type,
               grpc_service_name,
               grpc_method_name)
-            response_or_iterator = grpc_utils.wrap_iterator_inc_counter(
-              response_or_iterator,
-              GRPC_SERVER_STREAM_MSG_SENT,
-              grpc_type,
-              grpc_service_name,
-              grpc_method_name)
+
+          else:
+
+            if self._legacy:
+              LEGACY_GRPC_SERVER_HANDLED_TOTAL_COUNTER.labels(
+                grpc_type=grpc_type,
+                grpc_service=grpc_service_name,
+                grpc_method=grpc_method_name,
+                code=self._compute_status_code(servicer_context).name).inc()
+            else:
+              GRPC_SERVER_HANDLED_COUNTER.labels(
+                grpc_type=grpc_type,
+                grpc_service=grpc_service_name,
+                grpc_method=grpc_method_name,
+                code=self._compute_status_code(servicer_context).name).inc()
+
+          return response_or_iterator
+        except grpc.RpcError as e:
+
+          if self._legacy:
+            LEGACY_GRPC_SERVER_HANDLED_TOTAL_COUNTER.labels(
+              grpc_type=grpc_type,
+              grpc_service=grpc_service_name,
+              grpc_method=grpc_method_name,
+              code=self._compute_error_code(e)).inc()
           else:
             GRPC_SERVER_HANDLED_COUNTER.labels(
               grpc_type=grpc_type,
               grpc_service=grpc_service_name,
               grpc_method=grpc_method_name,
-              code=self._compute_status_code(servicer_context).name).inc()
-          return response_or_iterator
-        except grpc.RpcError as e:
-          GRPC_SERVER_HANDLED_COUNTER.labels(
-            grpc_type=grpc_type,
-            grpc_service=grpc_service_name,
-            grpc_method=grpc_method_name,
-            code=self._compute_error_code(e)).inc()
+              code=self._compute_error_code(e)).inc()
+
           raise e
+
         finally:
-          if not response_streaming and self._enable_handling_time_histogram:
-            GRPC_SERVER_HANDLED_HISTOGRAM.labels(
-              grpc_type=grpc_type,
-              grpc_service=grpc_service_name,
-              grpc_method=grpc_method_name) \
-              .observe(max(default_timer() - start, 0))
+
+          if not response_streaming:
+            if self._legacy:
+              LEGACY_GRPC_SERVER_HANDLED_LATENCY_SECONDS.labels(
+                grpc_type=grpc_type,
+                grpc_service=grpc_service_name,
+                grpc_method=grpc_method_name) \
+                .observe(max(default_timer() - start, 0))
+            elif self._enable_handling_time_histogram:
+              GRPC_SERVER_HANDLED_HISTOGRAM.labels(
+                grpc_type=grpc_type,
+                grpc_service=grpc_service_name,
+                grpc_method=grpc_method_name) \
+                .observe(max(default_timer() - start, 0))
 
       return new_behavior
 

--- a/py_grpc_prometheus/server_metrics.py
+++ b/py_grpc_prometheus/server_metrics.py
@@ -25,3 +25,31 @@ GRPC_SERVER_HANDLED_HISTOGRAM = Histogram(
   "grpc_server_handling_seconds",
   "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
   ["grpc_type", "grpc_service", "grpc_method"])
+
+# Legacy metrics for backward compatibility
+LEGACY_GRPC_SERVER_STARTED_TOTAL_COUNTER = Counter(
+  "grpc_server_started_total",
+  "Total number of RPCs started on the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])
+
+LEGACY_GRPC_SERVER_HANDLED_TOTAL_COUNTER = Counter(
+  "grpc_server_handled_total",
+  "Total number of RPCs completed on the server, regardless of success or failure.",
+  ["grpc_type", "grpc_service", "grpc_method", "code"])
+
+LEGACY_GRPC_SERVER_HANDLED_LATENCY_SECONDS = Histogram(
+  "grpc_server_handled_latency_seconds",
+  "Histogram of response latency (seconds) of gRPC that had been "
+  "application-level handled by the server",
+  ["grpc_type", "grpc_service", "grpc_method"])
+
+LEGACY_GRPC_MSG_RECEIVED_TOTAL_COUNTER = Counter(
+  "grpc_server_msg_received_total",
+  "Histogram of response latency (seconds) of gRPC that had been application-level "
+  "handled by the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])
+
+LEGACY_GRPC_MSG_SENT_TOTAL_COUNTER = Counter(
+  "grpc_server_msg_sent_total",
+  "Total number of stream messages sent by the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/server_metrics.py
+++ b/py_grpc_prometheus/server_metrics.py
@@ -2,26 +2,26 @@ from prometheus_client import Counter
 from prometheus_client import Histogram
 
 GRPC_SERVER_STARTED_COUNTER = Counter(
-    "grpc_server_started_total",
-    "Total number of RPCs started on the server.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_server_started_total",
+  "Total number of RPCs started on the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_SERVER_HANDLED_COUNTER = Counter(
-    "grpc_server_handled_total",
-    "Total number of RPCs completed on the server, regardless of success or failure.",
-    ["grpc_type", "grpc_service", "grpc_method", "grpc_code"])
+  "grpc_server_handled_total",
+  "Total number of RPCs completed on the server, regardless of success or failure.",
+  ["grpc_type", "grpc_service", "grpc_method", "grpc_code"])
 
 GRPC_SERVER_STREAM_MSG_RECEIVED = Counter(
-    "grpc_server_msg_received_total",
-    "Total number of RPC stream messages received on the server.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_server_msg_received_total",
+  "Total number of RPC stream messages received on the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_SERVER_STREAM_MSG_SENT = Counter(
-    "grpc_server_msg_sent_total",
-    "Total number of gRPC stream messages sent by the server.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_server_msg_sent_total",
+  "Total number of gRPC stream messages sent by the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_SERVER_HANDLED_HISTOGRAM = Histogram(
-    "grpc_server_handling_seconds",
-    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
-    ["grpc_type", "grpc_service", "grpc_method"])
+  "grpc_server_handling_seconds",
+  "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+  ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/server_metrics.py
+++ b/py_grpc_prometheus/server_metrics.py
@@ -43,13 +43,13 @@ LEGACY_GRPC_SERVER_HANDLED_LATENCY_SECONDS = Histogram(
   "application-level handled by the server",
   ["grpc_type", "grpc_service", "grpc_method"])
 
-LEGACY_GRPC_MSG_RECEIVED_TOTAL_COUNTER = Counter(
+LEGACY_GRPC_SERVER_MSG_RECEIVED_TOTAL_COUNTER = Counter(
   "grpc_server_msg_received_total",
   "Histogram of response latency (seconds) of gRPC that had been application-level "
   "handled by the server.",
   ["grpc_type", "grpc_service", "grpc_method"])
 
-LEGACY_GRPC_MSG_SENT_TOTAL_COUNTER = Counter(
+LEGACY_GRPC_SERVER_MSG_SENT_TOTAL_COUNTER = Counter(
   "grpc_server_msg_sent_total",
   "Total number of stream messages sent by the server.",
   ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/server_metrics.py
+++ b/py_grpc_prometheus/server_metrics.py
@@ -1,29 +1,27 @@
 from prometheus_client import Counter
 from prometheus_client import Histogram
 
-GRPC_SERVER_STARTED_TOTAL_COUNTER = Counter(
+GRPC_SERVER_STARTED_COUNTER = Counter(
     "grpc_server_started_total",
     "Total number of RPCs started on the server.",
     ["grpc_type", "grpc_service", "grpc_method"])
 
-GRPC_SERVER_HANDLED_TOTAL_COUNTER = Counter(
+GRPC_SERVER_HANDLED_COUNTER = Counter(
     "grpc_server_handled_total",
     "Total number of RPCs completed on the server, regardless of success or failure.",
-    ["grpc_type", "grpc_service", "grpc_method", "code"])
+    ["grpc_type", "grpc_service", "grpc_method", "grpc_code"])
+
+GRPC_SERVER_STREAM_MSG_RECEIVED = Counter(
+    "grpc_server_msg_received_total",
+    "Total number of RPC stream messages received on the server.",
+    ["grpc_type", "grpc_service", "grpc_method"])
+
+GRPC_SERVER_STREAM_MSG_SENT = Counter(
+    "grpc_server_msg_sent_total",
+    "Total number of gRPC stream messages sent by the server.",
+    ["grpc_type", "grpc_service", "grpc_method"])
 
 GRPC_SERVER_HANDLED_LATENCY_SECONDS = Histogram(
-    "grpc_server_handled_latency_seconds",
-    "Histogram of response latency (seconds) of gRPC that had been "
-    "application-level handled by the server",
-    ["grpc_type", "grpc_service", "grpc_method"])
-
-GRPC_SERVER_MSG_RECEIVED_TOTAL_COUNTER = Counter(
-    "grpc_server_msg_received_total",
-    "Histogram of response latency (seconds) of gRPC that had been application-level "
-    "handled by the server.",
-    ["grpc_type", "grpc_service", "grpc_method"])
-
-GRPC_SERVER_MSG_SENT_TOTAL_COUNTER = Counter(
-    "grpc_server_msg_sent_total",
-    "Total number of stream messages sent by the server.",
+    "grpc_server_handling_seconds",
+    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
     ["grpc_type", "grpc_service", "grpc_method"])

--- a/py_grpc_prometheus/server_metrics.py
+++ b/py_grpc_prometheus/server_metrics.py
@@ -21,7 +21,7 @@ GRPC_SERVER_STREAM_MSG_SENT = Counter(
     "Total number of gRPC stream messages sent by the server.",
     ["grpc_type", "grpc_service", "grpc_method"])
 
-GRPC_SERVER_HANDLED_LATENCY_SECONDS = Histogram(
+GRPC_SERVER_HANDLED_HISTOGRAM = Histogram(
     "grpc_server_handling_seconds",
     "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
     ["grpc_type", "grpc_service", "grpc_method"])


### PR DESCRIPTION
Update the metrics found in client_metrics.py and server_metrics.py to match the metric definitions found in https://github.com/grpc-ecosystem/go-grpc-prometheus/blob/master/client_metrics.go, and https://github.com/grpc-ecosystem/go-grpc-prometheus/blob/master/server_metrics.go.

Implement the optional turning on of histogram metrics on gRPC calls, similar to https://github.com/grpc-ecosystem/go-grpc-prometheus#histograms.

Update the README to reflect these changes.
