### PR TITLE
Update prometheus_server_interceptor.py

### DIFF
--- a/py_grpc_prometheus/prometheus_server_interceptor.py
+++ b/py_grpc_prometheus/prometheus_server_interceptor.py
@@ -82,11 +82,11 @@ class PromServerInterceptor(grpc.ServerInterceptor):
                                                               self._compute_status_code(
                                                                   servicer_context).name)
             return response_or_iterator
-          except grpc.RpcError as e:
+          except Exception as e:
             self.increase_grpc_server_handled_total_counter(grpc_type,
                                                             grpc_service_name,
                                                             grpc_method_name,
-                                                            self._compute_error_code(e).name)
+                                                            self._compute_status_code(servicer_context).name)
             raise e
 
           finally:


### PR DESCRIPTION
Updates the interceptor to count context.abort() and context.abort_with_status() calls, which are the recommended method for error-handling.

The python implementation of abort() raises a generic python Exception. The status code is stored in the servicer_context.

See https://github.com/grpc/grpc/blob/master/examples/python/errors/server.py. 
See https://github.com/grpc/grpc/blob/master/src/python/grpcio/grpc/_server.py#L407.